### PR TITLE
usdzconvert is not compatible with USD-23

### DIFF
--- a/usdzconvert/usdStageWithFbx.py
+++ b/usdzconvert/usdStageWithFbx.py
@@ -420,7 +420,7 @@ class FbxConverter:
 
             indices = self.getIndicesWithLayerElements(fbxMesh, fbxLayerNormals)
             interpolation = self.getInterpolationWithLayerElements(fbxLayerNormals)
-            normalPrimvar = usdMesh.CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, interpolation)
+            normalPrimvar = UsdGeom.PrimvarsAPI(usdMesh).CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, interpolation)
             normalPrimvar.Set(normals)
             if len(indices) != 0:
                 normalPrimvar.SetIndices(Vt.IntArray(indices))
@@ -454,7 +454,7 @@ class FbxConverter:
                 else:
                     texCoordSet = usdUtils.makeValidIdentifier(texCoordSet)
 
-            uvPrimvar = usdMesh.CreatePrimvar(texCoordSet, Sdf.ValueTypeNames.Float2Array, interpolation)
+            uvPrimvar = UsdGeom.PrimvarsAPI(usdMesh).CreatePrimvar(texCoordSet, Sdf.ValueTypeNames.Float2Array, interpolation)
             uvPrimvar.Set(uvs)
             if len(indices) != 0:
                 uvPrimvar.SetIndices(Vt.IntArray(indices))

--- a/usdzconvert/usdStageWithGlTF.py
+++ b/usdzconvert/usdStageWithGlTF.py
@@ -1139,7 +1139,7 @@ class glTFConverter:
                     if count == 0: # no indices
                         count = accessor.count
             elif key == 'NORMAL':
-                normalPrimvar = usdGeom.CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.vertex)
+                normalPrimvar = UsdGeom.PrimvarsAPI(usdGeom).CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.vertex)
                 normalPrimvar.Set(accessor.data)
             elif key == 'TANGENT':
                 pass
@@ -1157,7 +1157,7 @@ class glTFConverter:
 
                 texCoordSet = key[9:]
                 primvarName = 'st' if texCoordSet == '0' else 'st' + texCoordSet
-                uvs = usdGeom.CreatePrimvar(primvarName, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.vertex)
+                uvs = UsdGeom.PrimvarsAPI(usdGeom).CreatePrimvar(primvarName, Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.vertex)
                 uvs.Set(newData)
             elif key == 'COLOR_0':
                 data = accessor.data

--- a/usdzconvert/usdStageWithObj.py
+++ b/usdzconvert/usdStageWithObj.py
@@ -265,14 +265,14 @@ class ObjConverter:
 
         if minUvIndex >= 0:
             if group.uvsHaveOwnIndices:
-                uvPrimvar = usdMesh.CreatePrimvar('st', Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying)
+                uvPrimvar = UsdGeom.PrimvarsAPI(usdMesh).CreatePrimvar('st', Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.faceVarying)
                 uvPrimvar.Set(self.uvs[minUvIndex:maxUvIndex+1])
                 if minUvIndex == 0:  # optimization
                     uvPrimvar.SetIndices(Vt.IntArray(group.uvIndices))
                 else:
                     uvPrimvar.SetIndices(Vt.IntArray(list(map(lambda x: x - minUvIndex, group.uvIndices))))
             else:
-                uvPrimvar = usdMesh.CreatePrimvar('st', Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.vertex)
+                uvPrimvar = UsdGeom.PrimvarsAPI(usdMesh).CreatePrimvar('st', Sdf.ValueTypeNames.TexCoord2fArray, UsdGeom.Tokens.vertex)
                 uvPrimvar.Set(self.uvs[minUvIndex:maxUvIndex+1])
 
         # normals
@@ -281,14 +281,14 @@ class ObjConverter:
 
         if minNormalIndex >= 0:
             if group.normalsHaveOwnIndices:
-                normalPrimvar = usdMesh.CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.faceVarying)
+                normalPrimvar = UsdGeom.PrimvarsAPI(usdMesh).CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.faceVarying)
                 normalPrimvar.Set(self.normals[minNormalIndex:maxNormalIndex+1])
                 if minNormalIndex == 0:  # optimization
                     normalPrimvar.SetIndices(Vt.IntArray(group.normalIndices))
                 else:
                     normalPrimvar.SetIndices(Vt.IntArray(list(map(lambda x: x - minNormalIndex, group.normalIndices))))
             else:
-                normalPrimvar = usdMesh.CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.vertex)
+                normalPrimvar = UsdGeom.PrimvarsAPI(usdMesh).CreatePrimvar('normals', Sdf.ValueTypeNames.Normal3fArray, UsdGeom.Tokens.vertex)
                 normalPrimvar.Set(self.normals[minNormalIndex:maxNormalIndex+1])
 
         # materials


### PR DESCRIPTION
Access to the Primvars API has changed between USD-22.03 and USD-23.05 (current version), making `usdzconvert` fail to run.

This change enables `usdzconvert` to work with USD-23.05, but tests are needed before this can be merged.